### PR TITLE
Fix background image error

### DIFF
--- a/src/components/pokedex/pokedex.css
+++ b/src/components/pokedex/pokedex.css
@@ -17,7 +17,7 @@ body::before {
     left: 0;
     width: 200%;
     height: 200%;
-    background: url('pokemone-b.webp') repeat-x;
+    background: url("https://res.cloudinary.com/dyuuc32as/image/upload/v1757700010/pokemone-b_bgzx9f.webp") repeat-x;
     animation: moveClouds 60s linear infinite;
     opacity: 0.5;
     pointer-events: none;


### PR DESCRIPTION
When deploying a project, servers usually prefer serving images and assets through cloud-based services or CDNs rather than embedding them directly in project files.

so i put your image on cloud then it works fine on a deployment

<img width="1908" height="965" alt="image" src="https://github.com/user-attachments/assets/a27f66c8-80ed-4bd5-9634-f078a76a8f48" />

and here is a my deployment you can check it: https://pokiedex-react-app.vercel.app
